### PR TITLE
feat: use state broadcaster

### DIFF
--- a/crisp_controllers_robot_demos/config/fr3/controllers.yaml
+++ b/crisp_controllers_robot_demos/config/fr3/controllers.yaml
@@ -7,14 +7,8 @@
       joint_trajectory_controller:
         type: joint_trajectory_controller/JointTrajectoryController
 
-      joint_state_broadcaster:
-        type: joint_state_broadcaster/JointStateBroadcaster
-
-      twist_broadcaster:
-        type: crisp_controllers/TwistBroadcaster
-
-      pose_broadcaster:
-        type: crisp_controllers/PoseBroadcaster
+      state_broadcaster:
+        type: crisp_controllers/StateBroadcaster
 
       gravity_compensation:
         type: crisp_controllers/CartesianController
@@ -49,25 +43,7 @@
         fr3_joint6: { p: 150., d: 10., i: 0., i_clamp: 1. }
         fr3_joint7: { p: 50., d: 5., i: 0., i_clamp: 1. }
 
-  joint_state_broadcaster:
-    ros__parameters:
-      use_local_topics: False
-
-  twist_broadcaster:
-    ros__parameters:
-      joints:
-        - fr3_joint1
-        - fr3_joint2
-        - fr3_joint3
-        - fr3_joint4
-        - fr3_joint5
-        - fr3_joint6
-        - fr3_joint7
-
-      end_effector_frame: fr3_hand_tcp
-      base_frame: base
-
-  pose_broadcaster:
+  state_broadcaster:
     ros__parameters:
       joints:
         - fr3_joint1

--- a/crisp_controllers_robot_demos/config/fr3/left_controllers.yaml
+++ b/crisp_controllers_robot_demos/config/fr3/left_controllers.yaml
@@ -6,14 +6,8 @@ left:
       joint_trajectory_controller:
         type: joint_trajectory_controller/JointTrajectoryController
 
-      joint_state_broadcaster:
-        type: joint_state_broadcaster/JointStateBroadcaster
-
-      twist_broadcaster:
-        type: crisp_controllers/TwistBroadcaster
-
-      pose_broadcaster:
-        type: crisp_controllers/PoseBroadcaster
+      state_broadcaster:
+        type: crisp_controllers/StateBroadcaster
 
       gravity_compensation:
         type: crisp_controllers/CartesianController
@@ -54,25 +48,7 @@ left:
         left_fr3_joint6: { p: 150., d: 10., i: 0., i_clamp: 1. }
         left_fr3_joint7: { p: 50., d: 5., i: 0., i_clamp: 1. }
 
-  joint_state_broadcaster:
-    ros__parameters:
-      use_local_topics: False
-
-  twist_broadcaster:
-    ros__parameters:
-      joints:
-        - left_fr3_joint1
-        - left_fr3_joint2
-        - left_fr3_joint3
-        - left_fr3_joint4
-        - left_fr3_joint5
-        - left_fr3_joint6
-        - left_fr3_joint7
-
-      end_effector_frame: left_fr3_hand_tcp
-      base_frame: left_base
-
-  pose_broadcaster:
+  state_broadcaster:
     ros__parameters:
       joints:
         - left_fr3_joint1

--- a/crisp_controllers_robot_demos/config/fr3/right_controllers.yaml
+++ b/crisp_controllers_robot_demos/config/fr3/right_controllers.yaml
@@ -6,14 +6,8 @@ right:
       joint_trajectory_controller:
         type: joint_trajectory_controller/JointTrajectoryController
 
-      joint_state_broadcaster:
-        type: joint_state_broadcaster/JointStateBroadcaster
-
-      twist_broadcaster:
-        type: crisp_controllers/TwistBroadcaster
-
-      pose_broadcaster:
-        type: crisp_controllers/PoseBroadcaster
+      state_broadcaster:
+        type: crisp_controllers/StateBroadcaster
 
       gravity_compensation:
         type: crisp_controllers/CartesianController
@@ -54,25 +48,7 @@ right:
         right_fr3_joint6: { p: 150., d: 10., i: 0., i_clamp: 1. }
         right_fr3_joint7: { p: 50., d: 5., i: 0., i_clamp: 1. }
 
-  joint_state_broadcaster:
-    ros__parameters:
-      use_local_topics: False
-
-  twist_broadcaster:
-    ros__parameters:
-      joints:
-        - right_fr3_joint1
-        - right_fr3_joint2
-        - right_fr3_joint3
-        - right_fr3_joint4
-        - right_fr3_joint5
-        - right_fr3_joint6
-        - right_fr3_joint7
-
-      end_effector_frame: right_fr3_hand_tcp
-      base_frame: right_base
-
-  pose_broadcaster:
+  state_broadcaster:
     ros__parameters:
       joints:
         - right_fr3_joint1

--- a/crisp_controllers_robot_demos/config/iiwa/controllers.yaml
+++ b/crisp_controllers_robot_demos/config/iiwa/controllers.yaml
@@ -6,14 +6,8 @@
       joint_trajectory_controller:
         type: joint_trajectory_controller/JointTrajectoryController
 
-      joint_state_broadcaster:
-        type: joint_state_broadcaster/JointStateBroadcaster
-
-      twist_broadcaster:
-        type: crisp_controllers/TwistBroadcaster
-
-      pose_broadcaster:
-        type: crisp_controllers/PoseBroadcaster
+      state_broadcaster:
+        type: crisp_controllers/StateBroadcaster
 
       cartesian_impedance_controller:
         type: crisp_controllers/CartesianController
@@ -42,25 +36,7 @@
         joint_a6: { p: 1000., d: 10., i: 0., i_clamp: 1. }
         joint_a7: { p: 1000., d: 5., i: 0., i_clamp: 1. }
 
-  joint_state_broadcaster:
-    ros__parameters:
-      use_local_topics: False
-
-  twist_broadcaster:
-    ros__parameters:
-      joints:
-        - joint_a1
-        - joint_a2
-        - joint_a3
-        - joint_a4
-        - joint_a5
-        - joint_a6
-        - joint_a7
-
-      end_effector_frame: tool0
-      base_frame: iiwa_base
-
-  pose_broadcaster:
+  state_broadcaster:
     ros__parameters:
       joints:
         - joint_a1

--- a/crisp_controllers_robot_demos/config/kinova_gen3/controllers.yaml
+++ b/crisp_controllers_robot_demos/config/kinova_gen3/controllers.yaml
@@ -6,20 +6,14 @@
       joint_trajectory_controller:
         type: joint_trajectory_controller/JointTrajectoryController
 
-      joint_state_broadcaster:
-        type: joint_state_broadcaster/JointStateBroadcaster
-
-      twist_broadcaster:
-        type: crisp_controllers/TwistBroadcaster
+      state_broadcaster:
+        type: crisp_controllers/StateBroadcaster
 
       gravity_compensation:
         type: crisp_controllers/CartesianController
 
       cartesian_impedance_controller:
         type: crisp_controllers/CartesianController
-
-      pose_broadcaster:
-        type: crisp_controllers/PoseBroadcaster
 
       hardware_components_initial_state:
         unconfigured:
@@ -49,25 +43,7 @@
         joint6: { p: 150., d: 10., i: 0., i_clamp: 1. }
         joint7: { p: 50., d: 5., i: 0., i_clamp: 1. }
 
-  joint_state_broadcaster:
-    ros__parameters:
-      use_local_topics: False
-
-  twist_broadcaster:
-    ros__parameters:
-      joints:
-        - joint_1
-        - joint_2
-        - joint_3
-        - joint_4
-        - joint_5
-        - joint_6
-        - joint_7
-
-      end_effector_frame: end_effector_link
-      base_frame: base_link
-
-  pose_broadcaster:
+  state_broadcaster:
     ros__parameters:
       joints:
         - joint_1

--- a/crisp_controllers_robot_demos/launch/franka.launch.py
+++ b/crisp_controllers_robot_demos/launch/franka.launch.py
@@ -209,7 +209,7 @@ def generate_launch_description():
             Node(
                 package="controller_manager",
                 executable="spawner",
-                arguments=["joint_state_broadcaster"],
+                arguments=["state_broadcaster"],
                 output="screen",
             ),
             Node(
@@ -228,18 +228,6 @@ def generate_launch_description():
                 package="controller_manager",
                 executable="spawner",
                 arguments=["joint_trajectory_controller"],
-                output="screen",
-            ),
-            Node(
-                package="controller_manager",
-                executable="spawner",
-                arguments=["twist_broadcaster"],
-                output="screen",
-            ),
-            Node(
-                package="controller_manager",
-                executable="spawner",
-                arguments=["pose_broadcaster"],
                 output="screen",
             ),
             Node(

--- a/crisp_controllers_robot_demos/launch/iiwa.launch.py
+++ b/crisp_controllers_robot_demos/launch/iiwa.launch.py
@@ -280,11 +280,11 @@ def generate_launch_description():
         condition=UnlessCondition(use_planning),
     )
 
-    joint_state_broadcaster_spawner = Node(
+    state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
         arguments=[
-            "joint_state_broadcaster",
+            "state_broadcaster",
             "--controller-manager",
             [namespace, "controller_manager"],
         ],
@@ -311,35 +311,13 @@ def generate_launch_description():
         ],
     )
 
-    pose_broadcaster_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=[
-            "pose_broadcaster",
-            "--controller-manager",
-            "/controller_manager",
-        ],
-    )
-
-    twist_broadcaster_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=[
-            "twist_broadcaster",
-            "--controller-manager",
-            "/controller_manager",
-        ],
-    )
-
     nodes = [
         control_node,
         robot_state_pub_node,
         rviz_node,
         robot_controller_spawner,
-        joint_state_broadcaster_spawner,
+        state_broadcaster_spawner,
         cartesian_impedance_controller_spawner,
-        pose_broadcaster_spawner,
-        twist_broadcaster_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/crisp_controllers_robot_demos/launch/kinova_gen3.launch.py
+++ b/crisp_controllers_robot_demos/launch/kinova_gen3.launch.py
@@ -99,19 +99,7 @@ def generate_launch_description():
         Node(
             package="controller_manager",
             executable="spawner",
-            arguments=["joint_state_broadcaster"],
-            output="screen",
-        ),
-        Node(
-            package="controller_manager",
-            executable="spawner",
-            arguments=["pose_broadcaster"],
-            output="screen",
-        ),
-        Node(
-            package="controller_manager",
-            executable="spawner",
-            arguments=["twist_broadcaster"],
+            arguments=["state_broadcaster"],
             output="screen",
         ),
         Node(


### PR DESCRIPTION
Update demos with state broadcaster. Removes `pose_broadcaster` and `twist_broadcaster` from launch files and configurations entirely.